### PR TITLE
Fix existdb function signatures

### DIFF
--- a/src/lang-core/main/uk/co/reecedunn/intellij/plugin/intellij/lang/Implementations.kt
+++ b/src/lang-core/main/uk/co/reecedunn/intellij/plugin/intellij/lang/Implementations.kt
@@ -133,13 +133,19 @@ object EXistDB : Implementation("exist-db", "eXist-db", "http://www.exist-db.org
     val VERSION_3_6: Version = ProductVersion("3.6", this, "declare context item")
     val VERSION_4_0: Version = ProductVersion("4.0", this, "XQuery 3.1 REC")
     val VERSION_4_3: Version = ProductVersion("4.3", this, "XMLSchema 1.1")
+    val VERSION_5_0: Version = ProductVersion("5.0", this, "exist 5")
+    val VERSION_5_1: Version = ProductVersion("5.1", this, "Lucene facets and fields")
+    val VERSION_5_3: Version = ProductVersion("5.3", this, "Function types in context item")
 
     override val versions: List<Version> = listOf(
         VERSION_3_0,
         VERSION_3_1,
         VERSION_3_6,
         VERSION_4_0,
-        VERSION_4_3
+        VERSION_4_3,
+        VERSION_5_0,
+        VERSION_5_1,
+        VERSION_5_3
     )
 
     val EXIST_DB: Product = EXistDBProduct("exist-db", "eXist-db", this)
@@ -150,6 +156,7 @@ object EXistDB : Implementation("exist-db", "eXist-db", "http://www.exist-db.org
         dialect === this || dialect === XQuerySpec
 
     override fun staticContext(product: Product?, productVersion: Version?, xqueryVersion: Specification?): String? {
+        if (productVersion >= 5.0) return "urn:static-context:exist-db-5"
         return when (xqueryVersion) {
             XQuerySpec.REC_1_0_20070123, XQuerySpec.REC_1_0_20101214 ->
                 "urn:static-context:exist-db"

--- a/src/lang-xquery/main/resources/static-context/exist-db.org/exist-db-5.xqy
+++ b/src/lang-xquery/main/resources/static-context/exist-db.org/exist-db-5.xqy
@@ -1,0 +1,54 @@
+xquery version "1.0";
+(:~
+ : eXist default static context
+ :
+ : @see http://exist-db.org/exist/apps/fundocs/index.html
+ :)
+
+declare default element namespace "";
+declare default function namespace "http://www.w3.org/2005/xpath-functions"; (: = 'fn:' :)
+
+(: XQuery 1.0 :)
+declare namespace xml = "http://www.w3.org/XML/1998/namespace";
+declare namespace xs = "http://www.w3.org/2001/XMLSchema";
+declare namespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+declare namespace fn = "http://www.w3.org/2005/xpath-functions";
+declare namespace local = "http://www.w3.org/2005/xquery-local-functions";
+
+(: XQuery 3.0 :)
+declare namespace math = "http://www.w3.org/2005/xpath-functions/math";
+
+(: XQuery 3.1 :)
+declare namespace map = "http://www.w3.org/2005/xpath-functions/map";
+declare namespace array = "http://www.w3.org/2005/xpath-functions/array";
+
+(: eXist :)
+declare namespace compression = "http://exist-db.org/xquery/compression";
+declare namespace contentextraction = "http://exist-db.org/xquery/contentextraction";
+declare namespace counter = "http://exist-db.org/xquery/counter";
+declare namespace file = "http://exist-db.org/xquery/file";
+declare namespace image = "http://exist-db.org/xquery/image";
+declare namespace inspect = "http://exist-db.org/xquery/inspect";
+declare namespace ft = "http://exist-db.org/xquery/lucene";
+declare namespace mail = "http://exist-db.org/xquery/mail";
+declare namespace ngram = "http://exist-db.org/xquery/ngram";
+declare namespace process = "http://exist-db.org/xquery/process";
+declare namespace range = "http://exist-db.org/xquery/range";
+declare namespace repo = "http://exist-db.org/xquery/repo";
+declare namespace request = "http://exist-db.org/xquery/request";
+declare namespace response = "http://exist-db.org/xquery/response";
+declare namespace scheduler = "http://exist-db.org/xquery/scheduler";
+declare namespace sm = "http://exist-db.org/xquery/securitymanager";
+declare namespace session = "http://exist-db.org/xquery/session";
+declare namespace sort = "http://exist-db.org/xquery/sort";
+declare namespace sql = "http://exist-db.org/xquery/sql";
+declare namespace system = "http://exist-db.org/xquery/system";
+declare namespace transform = "http://exist-db.org/xquery/transform";
+declare namespace util = "http://exist-db.org/xquery/util";
+declare namespace validation = "http://exist-db.org/xquery/validation";
+declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
+declare namespace xmldiff = "http://exist-db.org/xquery/xmldiff";
+declare namespace xqdm = "http://exist-db.org/xquery/xqdoc";
+declare namespace xslfo = "http://exist-db.org/xquery/xslfo";
+
+()

--- a/src/lang-xquery/main/uk/co/reecedunn/intellij/plugin/xquery/model/StaticContextDefinitions.kt
+++ b/src/lang-xquery/main/uk/co/reecedunn/intellij/plugin/xquery/model/StaticContextDefinitions.kt
@@ -44,6 +44,7 @@ object StaticContextDefinitions {
     private val MODULES = mapOf(
         "urn:static-context:basex" to "static-context/basex.org/xquery.xqy",
         "urn:static-context:exist-db" to "static-context/exist-db.org/xquery.xqy",
+        "urn:static-context:exist-db-5" to "static-context/exist-db.org/exist-db-5.xqy",
         "urn:static-context:marklogic:0.9-ml" to "static-context/marklogic.com/0.9-ml.xqy",
         "urn:static-context:marklogic:1.0" to "static-context/marklogic.com/1.0.xqy",
         "urn:static-context:marklogic:1.0-ml" to "static-context/marklogic.com/1.0-ml.xqy",

--- a/src/plugin-existdb/main/resources/org/exist-db/xquery/lucene.xqy
+++ b/src/plugin-existdb/main/resources/org/exist-db/xquery/lucene.xqy
@@ -10,10 +10,17 @@ declare namespace a = "http://reecedunn.co.uk/xquery/annotations";
 declare namespace o = "http://reecedunn.co.uk/xquery/options";
 
 declare %a:since("exist", "4.4") function ft:close() as empty-sequence() external;
+declare %a:since("exist", "5.1") function ft:facets($nodes as node()*, $dimension as xs:string) as map(*) external;
+declare %a:since("exist", "5.1") function ft:facets($nodes as node()*, $dimension as xs:string, $count as xs:integer?) as map(*) external;
+declare %a:since("exist", "5.1") function ft:facets($nodes as node()*, $dimension as xs:string, $count as xs:integer?, $paths as xs:string+) as map(*) external;
+declare %a:since("exist", "5.1") function ft:field($node as node(), $field as xs:string) as xs:string* external;
+declare %a:since("exist", "5.1") function ft:field($node as node(), $field as xs:string, $type as xs:string) as item()* external;
 declare %a:since("exist", "4.4") function ft:get-field($path as xs:string*, $field as xs:string) as xs:string* external;
 declare %a:since("exist", "4.4") function ft:has-index($path as xs:string) as xs:boolean* external;
+declare %a:since("exist", "5.3") function ft:highlight-field-matches($node as node(), $field as xs:string) as element()? external;
 declare %a:since("exist", "4.4") function ft:index($documentPath as xs:string, $solrExression as node()) as empty-sequence() external;
 declare %a:since("exist", "4.4") function ft:index($documentPath as xs:string, $solrExression as node(), $close as xs:boolean) as empty-sequence() external;
+declare %a:since("exist", "5.1") function ft:index-keys-for-field($field as xs:string, $start-value as xs:string?, $function-reference as function(*), $max-number-returned as xs:int?) as item()* external;
 declare %a:since("exist", "4.4") function ft:optimize() as empty-sequence() external;
 declare %a:since("exist", "4.4") function ft:query($nodes as node()*, $query as item()) as node()* external;
 declare %a:since("exist", "4.4") function ft:query($nodes as node()*, $query as item(), $options as node()?) as node()* external;

--- a/src/plugin-existdb/main/resources/org/exist-db/xquery/util.xqy
+++ b/src/plugin-existdb/main/resources/org/exist-db/xquery/util.xqy
@@ -13,7 +13,8 @@ declare %a:since("exist", "4.4") function util:absolute-resource-id($node-or-pat
 declare %a:since("exist", "4.4") function util:base-to-integer($number as item(), $base as xs:integer) as xs:integer external;
 declare %a:since("exist", "4.4") function util:base64-decode($string as xs:string?) as xs:string? external;
 declare %a:since("exist", "4.4") function util:base64-encode($string as xs:string?) as xs:string? external;
-declare %a:since("exist", "4.4") function util:base64-encode($string as xs:string?, $trim as xs:boolean) as xs:string? external;
+declare %a:since("exist", "5.3") function util:base64-encode-url-safe($string as xs:string?) as xs:string? external;
+declare %a:deprecated("exist", "5.3") %a:since("exist", "4.4") function util:base64-encode($string as xs:string?, $trim as xs:boolean) as xs:string? external;
 declare %a:since("exist", "4.4") function util:binary-doc($binary-resource as xs:string?) as xs:base64Binary? external;
 declare %a:since("exist", "4.4") function util:binary-doc-available($binary-resource as xs:string?) as xs:boolean external;
 declare %a:since("exist", "4.6") function util:binary-doc-content-digest($binary-resource as xs:string?, $algorithm as xs:string) as xs:hexBinary? external;

--- a/src/plugin-existdb/main/resources/org/exist-db/xquery/xmldb.xqy
+++ b/src/plugin-existdb/main/resources/org/exist-db/xquery/xmldb.xqy
@@ -17,8 +17,12 @@ declare %a:since("exist", "4.4") %a:deprecated("exist", "4.4") %a:see-also("exis
 declare %a:since("exist", "4.4") %a:deprecated("exist", "4.4") %a:see-also("exist", "4.4", "sm:chmod") function xmldb:chmod-resource($collection as xs:string, $resource as xs:string, $mode as xs:integer) as item() external;
 declare %a:since("exist", "4.4") function xmldb:clear-lock($collection-uri as xs:string, $resource as xs:string) as xs:string? external;
 declare %a:since("exist", "4.4") function xmldb:collection-available($collection-uri as xs:string) as xs:boolean external;
-declare %a:since("exist", "4.4") function xmldb:copy($source-collection-uri as xs:string, $target-collection-uri as xs:string) as item() external;
-declare %a:since("exist", "4.4") function xmldb:copy($source-collection-uri as xs:string, $target-collection-uri as xs:string, $resource as xs:string) as item() external;
+declare %a:deprecated("exist", "5.0") %a:since("exist", "4.4") %a:see-also("exist", "5.0", "xmldb:copyt-resource") %a:see-also("exist", "5.0", "xmldb:copyt-collection") function xmldb:copy($source-collection-uri as xs:string, $target-collection-uri as xs:string) as item() external;
+declare %a:deprecated("exist", "5.0") %a:since("exist", "4.4") %a:see-also("exist", "5.0", "xmldb:copyt-resource") %a:see-also("exist", "5.0", "xmldb:copyt-collection") function xmldb:copy($source-collection-uri as xs:string, $target-collection-uri as xs:string, $resource as xs:string) as item() external;
+declare %a:since("exist", "5.0") function xmldb:copy-collection($source-collection-uri as xs:string, $target-collection-uri as xs:string) as xs:string external;
+declare %a:since("exist", "5.0") function xmldb:copy-collection($source-collection-uri as xs:string, $target-collection-uri as xs:string, $preserve as xs:boolean) as xs:string external;
+declare %a:since("exist", "5.0") function xmldb:copy-resource($source-collection-uri as xs:string, $source-resource-name as xs:string, $target-collection-uri as xs:string, $target-resource-name as xs:string?) as xs:string external;
+declare %a:since("exist", "5.0") function xmldb:copy-resource($source-collection-uri as xs:string, $source-resource-name as xs:string, $target-collection-uri as xs:string, $target-resource-name as xs:string?, $preserve as xs:boolean) as xs:string external;
 declare %a:since("exist", "4.4") function xmldb:create-collection($target-collection-uri as xs:string, $new-collection as xs:string) as xs:string? external;
 declare %a:since("exist", "4.4") %a:deprecated("exist", "4.4") %a:see-also("exist", "4.4", "sm:create-group") function xmldb:create-group($group as xs:string) as xs:boolean external;
 declare %a:since("exist", "4.4") %a:deprecated("exist", "4.4") %a:see-also("exist", "4.4", "sm:create-group") function xmldb:create-group($group as xs:string, $group-manager-username as xs:string+) as xs:boolean external;


### PR DESCRIPTION
With the releases of exist-db 5.0.0, 5.1.0 and 5.3.0 some function signatures changed, some where deprecated or even removed and new ones added.

This PR attempts to update all of these modules

- [x] xmldb
- [x] util
- [x] lucene

In addition this PR adds new processor versions 5.0, 5.1 and 5.3 (5.2 intentionally left out) and selects a new static XQuery context if version 5.0 or later is selected.